### PR TITLE
Showing aux memory information under docs on website

### DIFF
--- a/apps/frontend/src/App.tsx
+++ b/apps/frontend/src/App.tsx
@@ -11,6 +11,7 @@ import { ComparisonPage } from './pages/ComparisonPage';
 import { DocumentationPage } from './pages/DocumentationPage';
 import { DocumentationBaselinesPage } from './pages/DocumentationBaselinesPage';
 import { DocumentationDatasetsPage } from './pages/DocumentationDatasetsPage';
+import { DocumentationAuxMemoryPage } from './pages/DocumentationAuxMemoryPage';
 import { BaselineDetailPage } from './pages/BaselineDetailPage';
 import { ContributePage } from './pages/ContributePage';
 
@@ -56,6 +57,7 @@ function AppContent() {
             <Route path="/documentation/baselines/:baselineId" element={<BaselineDetailPage />} />
             <Route path="/documentation/datasets" element={<DocumentationDatasetsPage />} />
             <Route path="/documentation/datasets/:datasetId" element={<DatasetDetailPage />} />
+            <Route path="/documentation/auxiliary-memory" element={<DocumentationAuxMemoryPage />} />
             <Route path="/contribute" element={<ContributePage />} />
           </Routes>
           <Footer />

--- a/apps/frontend/src/components/layout/Sidebar.tsx
+++ b/apps/frontend/src/components/layout/Sidebar.tsx
@@ -267,6 +267,17 @@ export function Sidebar() {
                   </div>
                 ) : null}
               </div>
+                            {/* Auxiliary Memory Sub-section */}
+                            <Link
+                to="/documentation/auxiliary-memory"
+                className={`block px-3 py-2 rounded-lg text-sm font-medium transition-colors ${
+                  location.pathname === '/documentation/auxiliary-memory'
+                    ? 'bg-dark-surface-hover text-accent-gold'
+                    : 'text-gray-400 hover:bg-dark-surface-hover hover:text-white'
+                }`}
+              >
+                Auxiliary Memory
+              </Link>
             </div>
           )}
         </div>

--- a/apps/frontend/src/pages/DocumentationAuxMemoryPage.tsx
+++ b/apps/frontend/src/pages/DocumentationAuxMemoryPage.tsx
@@ -1,0 +1,216 @@
+import { Breadcrumb } from '../components/common/Breadcrumb';
+
+export function DocumentationAuxMemoryPage() {
+  return (
+    <div className="space-y-8">
+      <Breadcrumb />
+      
+      {/* Hero Section */}
+      <section>
+        <h1 className="text-4xl font-bold text-white mb-4">
+          Auxiliary Memory
+        </h1>
+        <p className="text-lg text-gray-400 max-w-3xl">
+          Understanding how auxiliary memory is computed for sparse attention methods
+        </p>
+      </section>
+
+      {/* Rationale Section */}
+      <section className="bg-dark-surface border border-dark-border rounded-lg p-8">
+        <h2 className="text-2xl font-bold text-white mb-4">
+          Rationale behind noting auxiliary memory used by sparse attention method
+        </h2>
+        <div className="space-y-4 text-gray-300">
+          <p>
+            Most sparse attention methods rely on additional metadata about the KV cache. For instance, 
+            Double Sparsity and HashAttention use label caches, while Quest employs page-level vectors. 
+            In general, greater memory usage tends to yield higher accuracy. In fact, methods like Quest 
+            and Double Sparsity asymptotically approach Oracle Top-k performance when they utilize the 
+            entire KV cache for index computation.
+          </p>
+          <p>
+            To distinguish between such configurations, we measure the auxiliary memory used by each 
+            method for computing sparse attention indices. Although, in principle, this cost could be 
+            captured by latency or throughput in a fully optimized implementation, our Tier 1A leaderboards 
+            aim to separate algorithmic quality from implementation efficiency. Therefore, to support fair 
+            comparison and enable researchers to work directly in PyTorch, we use auxiliary memory 
+            measurements as a discriminating factor among configurations of a given sparse attention method 
+            at given sparsity levels.
+          </p>
+        </div>
+      </section>
+
+      {/* Definition Section */}
+      <section className="bg-dark-surface border border-dark-border rounded-lg p-8">
+        <h2 className="text-2xl font-bold text-white mb-4">
+          Aux memory definition
+        </h2>
+        <div className="space-y-4 text-gray-300">
+          <p>
+            Auxiliary memory used by a sparse attention method is defined as the <strong className="text-white">number 
+            of bits per token, per KV attention head</strong> that the method requires for index computation.
+          </p>
+          <p>
+            For example, the Oracle method utilizes the entire KV cache, while HashAttention uses hat_bits 
+            per token per <strong className="text-white">query</strong> head — resulting in an overall auxiliary 
+            memory of group_size × hat_bits per <strong className="text-white">kv</strong> head. Detailed calculations 
+            for each method are provided below.
+          </p>
+        </div>
+
+        {/* Common Variables */}
+        <div className="mt-6 bg-black/30 border border-dark-border/60 rounded-lg p-4">
+          <h3 className="text-sm font-semibold text-accent-gold mb-3">Common Variables</h3>
+          <pre className="text-xs text-gray-200 space-y-1">
+            <code>
+{`head_dim = head dimension in model (e.g. 128 for meta-llama/Llama-3.1-8B-Instruct)
+group_size = num_attention_heads / num_kv_heads (e.g. 4 for meta-llama/Llama-3.1-8B-Instruct, etc)
+bits_precision = bit precision of model (e.g. 16 for bfloat16 etc.)`}
+            </code>
+          </pre>
+        </div>
+      </section>
+
+      {/* Methods Section */}
+      <section className="space-y-6">
+        <h2 className="text-2xl font-bold text-white">Calculation by Method</h2>
+
+        {/* Oracle Methods */}
+        <div className="bg-dark-surface border border-dark-border rounded-lg p-6">
+          <h3 className="text-xl font-semibold text-accent-gold mb-3">
+            Oracle Methods (Oracle-top-k, Oracle-top-p, vAttention(Oracle-top-k))
+          </h3>
+          <div className="bg-black/30 border border-dark-border/60 rounded-lg p-4 mb-3">
+            <pre className="text-sm text-gray-200">
+              <code>return head_dim * bits_precision</code>
+            </pre>
+          </div>
+          <p className="text-sm text-gray-400 italic">
+            Comment: oracle method use all the K embeddings
+          </p>
+        </div>
+
+        {/* StreamingLLM */}
+        <div className="bg-dark-surface border border-dark-border rounded-lg p-6">
+          <h3 className="text-xl font-semibold text-accent-gold mb-3">
+            StreamingLLM
+          </h3>
+          <div className="bg-black/30 border border-dark-border/60 rounded-lg p-4 mb-3">
+            <pre className="text-sm text-gray-200">
+              <code>return 0</code>
+            </pre>
+          </div>
+          <p className="text-sm text-gray-400 italic">
+            Comment: streaming methods do not use any information
+          </p>
+        </div>
+
+        {/* DoubleSparsity */}
+        <div className="bg-dark-surface border border-dark-border rounded-lg p-6">
+          <h3 className="text-xl font-semibold text-accent-gold mb-3">
+            DoubleSparsity
+          </h3>
+          <div className="bg-black/30 border border-dark-border/60 rounded-lg p-4 mb-3">
+            <pre className="text-sm text-gray-200 whitespace-pre-wrap">
+              <code>{`label_bits = sparse_attention_config["label_bits"]
+group_factor = sparse_attention_config["group_factor"]
+channel_selection = sparse_attention_config["channel_selection"]
+bits_per_q_head = label_bits * head_dim // group_factor
+
+if channel_selection in ["q_proj", "qk_proj"]:
+    bits_per_kv_head = bits_per_q_head * group_size
+elif channel_selection == "k_proj":
+    bits_per_kv_head = bits_per_q_head
+
+return bits_per_kv_head`}</code>
+            </pre>
+          </div>
+          <p className="text-sm text-gray-400 italic">
+            Comment: Double sparsity uses (head_dim // group_factor) channels with label_bits for each channel. 
+            In case of q based projection, it uses meta data per q head.
+          </p>
+        </div>
+
+        {/* HashAttention */}
+        <div className="bg-dark-surface border border-dark-border rounded-lg p-6">
+          <h3 className="text-xl font-semibold text-accent-gold mb-3">
+            HashAttention
+          </h3>
+          <div className="bg-black/30 border border-dark-border/60 rounded-lg p-4 mb-3">
+            <pre className="text-sm text-gray-200">
+              <code>{`hat_bits = sparse_attention_config["hat_bits"]
+return hat_bits * group_size`}</code>
+            </pre>
+          </div>
+          <p className="text-sm text-gray-400 italic">
+            Comment: HashAttention uses label_bits per q-head
+          </p>
+        </div>
+
+        {/* vAttention(HashAttention) */}
+        <div className="bg-dark-surface border border-dark-border rounded-lg p-6">
+          <h3 className="text-xl font-semibold text-accent-gold mb-3">
+            vAttention(HashAttention)
+          </h3>
+          <div className="bg-black/30 border border-dark-border/60 rounded-lg p-4 mb-3">
+            <pre className="text-sm text-gray-200">
+              <code>{`hat_bits = sparse_attention_config["hat_bits"]
+hashattention_bits = hat_bits * group_size
+sample_bits = sparse_attention_config["base_rate_sampling"] * head_dim * bits_precision
+return hashattention_bits + sample_bits`}</code>
+            </pre>
+          </div>
+          <p className="text-sm text-gray-400 italic">
+            Comment: vAttention uses additional sample of KV Cache. we account for its bits used. 
+            Ideally this can be reduced further if we store quantized base sample.
+          </p>
+        </div>
+
+        {/* MagicPig */}
+        <div className="bg-dark-surface border border-dark-border rounded-lg p-6">
+          <h3 className="text-xl font-semibold text-accent-gold mb-3">
+            MagicPig
+          </h3>
+          <div className="bg-black/30 border border-dark-border/60 rounded-lg p-4 mb-3">
+            <pre className="text-sm text-gray-200">
+              <code>{`lsh_l = sparse_attention_config["lsh_l"]
+return lsh_l * 32  # int32 for storing indices`}</code>
+            </pre>
+          </div>
+          <p className="text-sm text-gray-400 italic">
+            Comment: Magic uses lsh_l LSH tables. We assume 32 bit integers.
+          </p>
+        </div>
+
+        {/* Quest */}
+        <div className="bg-dark-surface border border-dark-border rounded-lg p-6">
+          <h3 className="text-xl font-semibold text-accent-gold mb-3">
+            Quest
+          </h3>
+          <div className="bg-black/30 border border-dark-border/60 rounded-lg p-4 mb-3">
+            <pre className="text-sm text-gray-200">
+              <code>{`page_size = sparse_attention_config["page_size"]
+return 2 * head_dim // page_size * bits_precision`}</code>
+            </pre>
+          </div>
+          <p className="text-sm text-gray-400 italic">
+            Comment: Quest stores 2 vectors per page.
+          </p>
+        </div>
+
+        {/* PQCache */}
+        <div className="bg-dark-surface border border-dark-border rounded-lg p-6">
+          <h3 className="text-xl font-semibold text-accent-gold mb-3">
+            PQCache
+          </h3>
+          <div className="bg-black/30 border border-dark-border/60 rounded-lg p-4">
+            <pre className="text-sm text-gray-400 italic">
+              <code>To be added</code>
+            </pre>
+          </div>
+        </div>
+      </section>
+    </div>
+  );
+}
+

--- a/apps/frontend/src/pages/DocumentationPage.tsx
+++ b/apps/frontend/src/pages/DocumentationPage.tsx
@@ -30,7 +30,7 @@ export function DocumentationPage() {
       </section>
 
       {/* Documentation Categories */}
-      <section className="grid grid-cols-1 md:grid-cols-2 gap-6">
+      <section className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
         {/* Baselines Card */}
         <Link
           to="/documentation/baselines"
@@ -79,6 +79,33 @@ export function DocumentationPage() {
           </p>
           <div className="flex items-center gap-2 text-accent-gold font-medium">
             <span>View datasets</span>
+            <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
+            </svg>
+          </div>
+        </Link>
+
+        {/* Auxiliary Memory Card */}
+        <Link
+          to="/documentation/auxiliary-memory"
+          className="group bg-dark-surface border border-dark-border rounded-lg p-8 hover:border-accent-gold transition-colors"
+        >
+          <div className="flex items-center gap-4 mb-4">
+            <div className="w-12 h-12 rounded-lg bg-accent-gold/10 flex items-center justify-center">
+              <svg className="w-6 h-6 text-accent-gold" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 3v2m6-2v2M9 19v2m6-2v2M5 9H3m2 6H3m18-6h-2m2 6h-2M7 19h10a2 2 0 002-2V7a2 2 0 00-2-2H7a2 2 0 00-2 2v10a2 2 0 002 2zM9 9h6v6H9V9z" />
+              </svg>
+            </div>
+            <h2 className="text-2xl font-bold text-white group-hover:text-accent-gold transition-colors">
+              Auxiliary Memory
+            </h2>
+          </div>
+          <p className="text-gray-300 mb-4">
+            Learn how auxiliary memory is computed for different sparse attention methods. 
+            Understand the memory requirements and trade-offs for each approach.
+          </p>
+          <div className="flex items-center gap-2 text-accent-gold font-medium">
+            <span>View guide</span>
             <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
             </svg>


### PR DESCRIPTION

https://github.com/user-attachments/assets/74da31b4-921f-41db-99c4-7642ede23c5b

Displaying the auxiliary memory information for different baselines
