### PR TITLE
Improvements on dataset page and overview page

### DIFF
--- a/apps/frontend/src/components/leaderboard/LeaderboardTable.tsx
+++ b/apps/frontend/src/components/leaderboard/LeaderboardTable.tsx
@@ -1,6 +1,7 @@
 import type { DatasetRanking, Metric } from '@sky-light/shared-types';
 import { SortableHeader } from '../common/SortableHeader';
 import { useSortableData } from '../../hooks/useSortableData';
+import { InfoTooltip } from '../common/InfoTooltip';
 
 interface LeaderboardTableProps {
   entries: DatasetRanking[];
@@ -38,42 +39,72 @@ export function LeaderboardTable({ entries, metrics = [] }: LeaderboardTableProp
         <thead>
           <tr className="border-b border-dark-border">
             <SortableHeader
-              label="Rank"
+              label={
+                <div className="flex items-center gap-1">
+                  Rank
+                  <InfoTooltip content="Position in the leaderboard based on score for this dataset." />
+                </div>
+              }
               sortKey="rank"
               sortConfig={sortConfig}
               onSort={requestSort}
               align="left"
             />
             <SortableHeader
-              label="Baseline"
+              label={
+                <div className="flex items-center gap-1">
+                  Baseline
+                  <InfoTooltip content="The sparse attention implementation being evaluated." />
+                </div>
+              }
               sortKey="baseline.name"
               sortConfig={sortConfig}
               onSort={requestSort}
               align="left"
             />
             <SortableHeader
-              label="LLM"
+              label={
+                <div className="flex items-center gap-1">
+                  LLM
+                  <InfoTooltip content="The Large Language Model used for testing." />
+                </div>
+              }
               sortKey="llm.name"
               sortConfig={sortConfig}
               onSort={requestSort}
               align="left"
             />
             <SortableHeader
-              label="Score"
+              label={
+                <div className="flex items-center gap-1">
+                  Score
+                  <InfoTooltip content="Performance score on this dataset. Higher is better. Used as secondary sort." />
+                </div>
+              }
               sortKey="score"
               sortConfig={sortConfig}
               onSort={requestSort}
               align="right"
             />
             <SortableHeader
-              label="Avg Density (%)"
+              label={
+                <div className="flex items-center gap-1">
+                  Avg Density (%)
+                  <InfoTooltip content="Average attention density - percentage of tokens used in attention computation." />
+                </div>
+              }
               sortKey="metricValues.average_density"
               sortConfig={sortConfig}
               onSort={requestSort}
               align="right"
             />
             <SortableHeader
-              label="Aux Memory"
+              label={
+                <div className="flex items-center gap-1">
+                  Aux Memory
+                  <InfoTooltip content="Auxiliary memory used by the sparse attention method (in bits per token)." />
+                </div>
+              }
               sortKey="targetAuxMemory"
               sortConfig={sortConfig}
               onSort={requestSort}

--- a/apps/frontend/src/hooks/useSortableData.ts
+++ b/apps/frontend/src/hooks/useSortableData.ts
@@ -37,9 +37,19 @@ export function useSortableData<T>(data: T[], initialSort?: SortConfig<T>) {
     }
 
     return [...data].sort((a, b) => {
+      // Primary sort
       const aValue = getNestedValue(a, sortConfig.key as string);
       const bValue = getNestedValue(b, sortConfig.key as string);
-      return compareValues(aValue, bValue, sortConfig.direction);
+      const primaryComparison = compareValues(aValue, bValue, sortConfig.direction);
+      
+      // If primary sort values are equal and not sorting by 'score', use score as secondary sort (descending)
+      if (primaryComparison === 0 && sortConfig.key !== 'score') {
+        const aScore = getNestedValue(a, 'score');
+        const bScore = getNestedValue(b, 'score');
+        return compareValues(aScore, bScore, 'desc');
+      }
+      
+      return primaryComparison;
     });
   }, [data, sortConfig]);
 


### PR DESCRIPTION
- For the model config that is displayed, now displaying the one for each dataset by clicking on it
- Making information per header available on the individual dataset page
- Keeping secondary scoring for accuracy, helpful when filtering by baseline (see attached screenshot)

<img width="1042" height="756" alt="Screenshot 2025-11-15 at 1 44 13 PM" src="https://github.com/user-attachments/assets/f8029f03-4c46-40db-aa99-aabc24e8a6b5" />
<img width="874" height="752" alt="Screenshot 2025-11-15 at 1 45 37 PM" src="https://github.com/user-attachments/assets/730c99ff-c06d-4dd3-a7b1-7e8aae50f2f9" />
