### PR TITLE
fixing text appearance changes - basic

### DIFF
--- a/apps/frontend/src/components/leaderboard/AggregatedTable.tsx
+++ b/apps/frontend/src/components/leaderboard/AggregatedTable.tsx
@@ -268,7 +268,6 @@ export function AggregatedTable({ rankings }: AggregatedTableProps) {
                 >
                   {ranking.baseline.name}
                 </Link>
-                <div className="text-xs text-gray-400 max-w-xs truncate">{ranking.baseline.description}</div>
                 <div className="text-xs text-gray-500 mt-1">
                   {`Evaluated on ${ranking.numDatasets}/${ranking.totalNumDatasets} datasets`}
                 </div>
@@ -375,9 +374,6 @@ export function AggregatedTable({ rankings }: AggregatedTableProps) {
                                   </svg>
                                   <div className="flex-1 min-w-0">
                                     <div className="text-xs text-gray-500 truncate">{ranking.llm.name} - {ranking.baseline.name}</div>
-                                    <div className="text-xs text-gray-600 truncate">
-                                      Click to {isDatasetExpanded ? 'hide' : 'view'} config
-                                    </div>
                                   </div>
                                 </div>
                               </td>


### PR DESCRIPTION
- Removing sparse attention method: xxxxx under entries
- Removing 'click to view config' text on overview page
<img width="856" height="524" alt="Screenshot 2025-11-17 at 5 38 36 PM" src="https://github.com/user-attachments/assets/29415f49-7c6c-4b37-9325-de149d61d28b" />
